### PR TITLE
Feature/lprobsth logout

### DIFF
--- a/Gitlab.php
+++ b/Gitlab.php
@@ -74,7 +74,7 @@ class Gitlab extends AbstractOAuth2Base
         ];
 
         $this->httpClient->retrieveResponse(
-            new Uri($plugin->getConf('url').'oauth/revoke'),
+            new Uri($plugin->getConf('url').'/oauth/revoke'),
             $parameters,
             $this->getExtraOAuthHeaders()
         );

--- a/Gitlab.php
+++ b/Gitlab.php
@@ -54,4 +54,29 @@ class Gitlab extends AbstractOAuth2Base
     {
         return static::AUTHORIZATION_METHOD_HEADER_BEARER;
     }
+
+    /**
+     * Logout from GitLab
+     *
+     * @return void
+     * @throws \OAuth\Common\Exception\Exception
+     */
+    public function logout()
+    {
+        $plugin = plugin_load('helper', 'oauthgitlab');
+
+        $token = $this->getStorage()->retrieveAccessToken($this->service());
+
+        $parameters = [
+            'client_id' => $this->credentials->getConsumerId(),
+            'client_secret' => $this->credentials->getConsumerSecret(),
+            'token' => $token,
+        ];
+
+        $this->httpClient->retrieveResponse(
+            new Uri($plugin->getConf('url').'oauth/revoke'),
+            $parameters,
+            $this->getExtraOAuthHeaders()
+        );
+    }
 }

--- a/Gitlab.php
+++ b/Gitlab.php
@@ -63,6 +63,8 @@ class Gitlab extends AbstractOAuth2Base
      */
     public function logout()
     {
+        global $ID;
+
         $plugin = plugin_load('helper', 'oauthgitlab');
 
         $token = $this->getStorage()->retrieveAccessToken($this->service());
@@ -70,7 +72,7 @@ class Gitlab extends AbstractOAuth2Base
         $parameters = [
             'client_id' => $this->credentials->getConsumerId(),
             'client_secret' => $this->credentials->getConsumerSecret(),
-            'token' => $token,
+            'token' => $token
         ];
 
         $this->httpClient->retrieveResponse(
@@ -78,5 +80,8 @@ class Gitlab extends AbstractOAuth2Base
             $parameters,
             $this->getExtraOAuthHeaders()
         );
+
+        $parameters = array();
+        send_redirect(wl($ID, $parameters, true, '&'));
     }
 }

--- a/action.php
+++ b/action.php
@@ -172,5 +172,16 @@ class action_plugin_oauthgitlab extends \dokuwiki\plugin\oauth\Adapter
         
         return $this->checkMatchRules();
     }
+
+    /**
+     * @inheritdoc
+     * @throws \OAuth\Common\Exception\Exception
+     */
+    public function logout()
+    {
+        /** @var Gitlab */
+        $oauth = $this->getOAuthService();
+        $oauth->logout();
+    }
 }
 

--- a/action.php
+++ b/action.php
@@ -40,7 +40,7 @@ class action_plugin_oauthgitlab extends \dokuwiki\plugin\oauth\Adapter
     /** @inheritDoc */
     public function getScopes()
     {
-        return array('read_user');
+        return array('read_user','api');
     }
 
     /** @inheritDoc */

--- a/action.php
+++ b/action.php
@@ -119,7 +119,7 @@ class action_plugin_oauthgitlab extends \dokuwiki\plugin\oauth\Adapter
             }
             
             // ns/key/subkey/subsubkey.. [ (!=|=) value ]
-            if (!preg_match('#^\s*([a-z-_]+)/([a-z-_/]+)\s*(?:(!?=)\s*(.+))?$#i', $rule, $match)) {
+            if (!preg_match('#^\s*([a-z-_]+)/([a-z-_/\s]+)\s*(?:(!?=)\s*(.+))?$#i', $rule, $match)) {
                 dbglog('Wrong gitlab rule format '.$rule.'. Ignoring.');
                 continue;
             }

--- a/action.php
+++ b/action.php
@@ -98,9 +98,9 @@ class action_plugin_oauthgitlab extends \dokuwiki\plugin\oauth\Adapter
     public function checkMatchRules() {
         
         /** @var helper_plugin_oauth $hlp */
-        $hlp     = plugin_load('helper', 'oauth');
+        $hlp     = plugin_load('helper', 'oauthgitlab');
         
-        if (!$rules = trim($hlp->getConf('gitlab-rules'))) {
+        if (!$rules = trim($hlp->getConf('rules'))) {
             return true;
         }
         


### PR DESCRIPTION
Fix several critical bugs:
- if a space was contained in the login rule (e.g. "name/Fancy Group Name") the plugin was silently failing and letting anybody in
- the login rules were read from the wrong config entry
- when requesting the oath token the plugin was not requesting the necessary scopes for accessing group information